### PR TITLE
Interpolated projection operator

### DIFF
--- a/src/PRONTO.jl
+++ b/src/PRONTO.jl
@@ -214,6 +214,7 @@ function pronto(θ::Model, x0::StaticVector, ξ::Trajectory, τ;
                 show_info = true,
                 show_preview = true,
                 show_steps = false,
+                resample_dt = 0.001,
                 armijo_kw...)
                 
     solve_start = time_ns()
@@ -247,7 +248,7 @@ function pronto(θ::Model, x0::StaticVector, ξ::Trajectory, τ;
         push!(data.vo, vo)
 
         show_steps && iinfo("search direction")
-        ζ = search_direction(θ,ξ,Ko,vo,τ)
+        ζ = search_direction(θ, ξ, Ko, vo, τ; resample_dt)
         push!(data.ζ, ζ)
 
         
@@ -269,7 +270,7 @@ function pronto(θ::Model, x0::StaticVector, ξ::Trajectory, τ;
 
         # -------------- select γ via armijo step -------------- #
         show_steps && iinfo("armijo backstep")
-        φ,γ = armijo(θ, x0, ξ, ζ, Kr, h, Dh, τ; armijo_kw...)
+        φ,γ = armijo(θ, x0, ξ, ζ, Kr, h, Dh, τ; resample_dt, armijo_kw...)
         push!(data.γ, γ)
         push!(data.φ, φ) 
 

--- a/src/armijo.jl
+++ b/src/armijo.jl
@@ -3,6 +3,7 @@
 # ----------------------------------- armijo step line search ----------------------------------- #
 
 function armijo(θ, x0, ξ, ζ, Kr, h, Dh, τ;
+                resample_dt = 0.001,
                 armijo_maxiters = 25,
                 show_armijo = false,
                 α = 0.4,
@@ -13,7 +14,7 @@ function armijo(θ, x0, ξ, ζ, Kr, h, Dh, τ;
     φ = ξ
     while γ > γmin
         show_armijo && iiinfo("γ = $(round(γ; digits=6))")
-        φ = armijo_projection(θ,x0,ξ,ζ,γ,Kr,τ)
+        φ = armijo_projection(θ, x0, ξ, ζ, γ, Kr, τ; resample_dt)
         g = cost(φ, τ)
         h-g >= -α*γ*Dh ? break : (γ *= β)
     end
@@ -24,10 +25,10 @@ end
 
 armijo_projection(θ,x0,ξ,ζ,γ,Kr,τ; kw...) = armijo_projection(θ,x0,ξ.x,ξ.u,ζ.x,ζ.u,γ,Kr,τ; kw...)
 
-function armijo_projection(θ::Model{NX,NU},x0,x,u,z,v,γ,Kr,τ; dt=0.001, kw...) where {NX,NU}
+function armijo_projection(θ::Model{NX,NU},x0,x,u,z,v,γ,Kr,τ; resample_dt=0.001, kw...) where {NX,NU}
     ubuf = Vector{SVector{NU,Float64}}()
     xbuf = Vector{SVector{NX,Float64}}()
-    t0,tf = τ; ts = t0:dt:tf
+    t0,tf = τ; ts = t0:resample_dt:tf
 
     cb = FunctionCallingCallback(funcat = ts, func_start = false) do x1,t,integrator
         (θ,x,u,z,v,γ,Kr) = integrator.p

--- a/src/armijo.jl
+++ b/src/armijo.jl
@@ -26,6 +26,7 @@ armijo_projection(θ,x0,ξ,ζ,γ,Kr,τ; kw...) = armijo_projection(θ,x0,ξ.x,ξ
 
 function armijo_projection(θ::Model{NX,NU},x0,x,u,z,v,γ,Kr,τ; dt=0.001, kw...) where {NX,NU}
     ubuf = Vector{SVector{NU,Float64}}()
+    xbuf = Vector{SVector{NX,Float64}}()
     t0,tf = τ; ts = t0:dt:tf
 
     cb = FunctionCallingCallback(funcat = ts, func_start = false) do x1,t,integrator
@@ -37,10 +38,12 @@ function armijo_projection(θ::Model{NX,NU},x0,x,u,z,v,γ,Kr,τ; dt=0.001, kw...
         u = μ - Kr*(x1-α)
 
         push!(ubuf, SVector{NU,Float64}(u))
+        push!(xbuf, SVector{NX,Float64}(x1))
     end
 
-    x = ODE(dxdt_armijo, x0, (t0,tf), (θ,x,u,z,v,γ,Kr); callback = cb, saveat = ts, kw...)
-    u = Interpolant(scale(interpolate(ubuf, BSpline(Linear())), ts))
+    ODE(dxdt_armijo, x0, (t0,tf), (θ,x,u,z,v,γ,Kr); callback = cb, dense=false, kw...)
+    x = Interpolant(scale(interpolate(xbuf, BSpline(Cubic())), ts))
+    u = Interpolant(scale(interpolate(ubuf, BSpline(Cubic())), ts))
 
     return Trajectory(θ,x,u)
 end

--- a/src/odes.jl
+++ b/src/odes.jl
@@ -33,7 +33,7 @@ function ODE(fn::Function, ic, ts, p, ::Size{S}; alg=Tsit5(), kw...) where {S}
 
     soln! = solve(ODEProblem(fn, ic, ts, p),
             alg;
-            reltol=1e-7,
+            reltol=1e-8,
             kw...)
 
     T = SArray{Tuple{S...}, Float64, length(S), prod(S)}

--- a/src/projection.jl
+++ b/src/projection.jl
@@ -41,9 +41,9 @@ function projection(θ::Model{NX,NU}, x0, α, μ, Kr, (t0,tf); dt=0.001) where {
         push!(ubuf, SVector{NU,Float64}(u))
     end  
 
-    x = ODE(dxdt, x0, (t0,tf), (θ,α,μ,Kr); callback = cb, saveat = ts)
-    # x = Interpolant(scale(interpolate(xbuf, BSpline(Linear())), ts))
-    u = Interpolant(scale(interpolate(ubuf, BSpline(Linear())), ts))
+    ODE(dxdt, x0, (t0,tf), (θ,α,μ,Kr); callback = cb, saveat = ts)
+    x = Interpolant(scale(interpolate(xbuf, BSpline(Cubic())), ts))
+    u = Interpolant(scale(interpolate(ubuf, BSpline(Cubic())), ts))
 
     return Trajectory(θ,x,u)
 end

--- a/src/search_direction.jl
+++ b/src/search_direction.jl
@@ -196,9 +196,9 @@ is2ndorder(::Any) = false
 # ----------------------------------- search direction ----------------------------------- #
 
 
-function search_direction(θ::Model{NX,NU},ξ,Ko,vo,τ; dt=0.001) where {NX,NU}
+function search_direction(θ::Model{NX,NU},ξ,Ko,vo,τ; resample_dt=0.001) where {NX,NU}
     t0,tf = τ
-    ts = t0:dt:tf
+    ts = t0:resample_dt:tf
     vbuf = Vector{SVector{NU,Float64}}()
     zbuf = Vector{SVector{NX,Float64}}()
 

--- a/src/search_direction.jl
+++ b/src/search_direction.jl
@@ -200,6 +200,8 @@ function search_direction(θ::Model{NX,NU},ξ,Ko,vo,τ; dt=0.001) where {NX,NU}
     t0,tf = τ
     ts = t0:dt:tf
     vbuf = Vector{SVector{NU,Float64}}()
+    zbuf = Vector{SVector{NX,Float64}}()
+
 
     cb = FunctionCallingCallback(funcat = ts) do z,t,integrator
         (_,ξ,Ko,vo) = integrator.p
@@ -209,10 +211,12 @@ function search_direction(θ::Model{NX,NU},ξ,Ko,vo,τ; dt=0.001) where {NX,NU}
         v = vo(x,u,t) - Ko(x,u,t)*z
 
         push!(vbuf, SVector{NU,Float64}(v))
+        push!(zbuf, SVector{NX,Float64}(z))
     end
     z0 = zeros(SVector{NX,Float64})
-    z = ODE(dz_dt, z0, (t0,tf), (θ,ξ,Ko,vo); callback = cb, saveat = ts)
-    v = Interpolant(scale(interpolate(vbuf, BSpline(Linear())), ts))
+    ODE(dz_dt, z0, (t0,tf), (θ,ξ,Ko,vo); callback = cb, dense = false)
+    z = Interpolant(scale(interpolate(zbuf, BSpline(Cubic())), ts))
+    v = Interpolant(scale(interpolate(vbuf, BSpline(Cubic())), ts))
 
     return Trajectory(θ,z,v)
 end


### PR DESCRIPTION
Fixes #16 

Changes the projection operator and search direction steps to represent `x` and `z` respectively using cubic spline interpolation on a fixed time step instead of wrapping the `ODESolution`. Slightly reduces solver performance, and is meant as an interim solution. Adds a kwarg `resample_dt` to adjust the fixed time step.

See #16 for more details.