### PR TITLE
Q/Qr and R/Rr macro aliases

### DIFF
--- a/src/PRONTO.jl
+++ b/src/PRONTO.jl
@@ -37,6 +37,7 @@ import Base: extrema, length, eachindex, show, size, eltype, getproperty, getind
 
 
 export @define_f, @define_l, @define_m, @define_Qr, @define_Rr
+export @define_Q, @define_R
 export @dynamics, @incremental_cost, @terminal_cost, @regulator_Q, @regulator_R
 export resolve_model, symbolic
 export zero_input, open_loop, closed_loop, smooth

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -46,6 +46,10 @@ var"@terminal_cost" = var"@define_m"
 var"@regulator_Q" = var"@define_Qr"
 var"@regulator_R" = var"@define_Rr"
 
+# aliases to maintain support for v1.0.0 syntax
+var"@define_Q" = var"@define_Qr"
+var"@define_R" = var"@define_Rr"
+
 # run before using model, ensures all methods are generated
 function resolve_model(T::Type{<:Model})
     define_L(T)


### PR DESCRIPTION
Adds aliases to the `define_Qr` (`define_Q`) and `define_Rr` (`define_R`) macros to support the new syntax while preserving support for the API of v1.0.0